### PR TITLE
Fix issues due to pip update and missing environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ export ENV_PREFIX=$PWD/env
 export HOROVOD_CUDA_HOME=$CUDA_HOME
 export HOROVOD_NCCL_HOME=$ENV_PREFIX
 export HOROVOD_GPU_OPERATIONS=NCCL
+export HOROVOD_NCCL_LINK=SHARED
 conda env create --prefix $ENV_PREFIX --file environment.yml --force
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Project organization is based on ideas from [_Good Enough Practices for Scientif
 
 You will need to have the [appropriate version](https://developer.nvidia.com/cuda-toolkit-archive) 
 of the NVIDIA CUDA Toolkit installed on your workstation. For this repo we are using 
-[NVIDIA CUDA Toolkit 10.1](https://developer.nvidia.com/cuda-10.1-download-archive-update2) 
-[(documentation)](https://docs.nvidia.com/cuda/archive/10.1/).
+[NVIDIA CUDA Toolkit 11.0](https://developer.nvidia.com/cuda-11.0-update1-download-archive) 
+[(documentation)](https://docs.nvidia.com/cuda/archive/11.0/).
 
 After installing the appropriate version of the NVIDIA CUDA Toolkit you will need to set the 
 following environment variables.
 
 ```bash
-$ export CUDA_HOME=/usr/local/cuda-10.1
+$ export CUDA_HOME=/usr/local/cuda-11.0
 $ export PATH=$CUDA_HOME/bin:$PATH
 $ export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
 ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ horovodrun --check-build
 You should see output similar to the following.
 
 ```
-Horovod v0.19.1:
+Horovod v0.21.3:
 
 Available Frameworks:
     [X] TensorFlow

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pip
   - pip:
     - tensorflow-gpu==2.4.*
-    - -r file:requirements.txt
+    - -r requirements.txt
   - python=3.8
   - pytorch=1.7
   - tensorboard=2.4


### PR DESCRIPTION
Hi,

initially I could not install the conda environment on my own machine.

The first error message:
```
AttributeError: 'FileNotFoundError' object has no attribute 'read'
```
can be attributed to [outdated syntax](https://stackoverflow.com/questions/68571543/using-a-pip-requirements-file-in-a-conda-yml-file-throws-attributeerror-fileno) with respect to the requirement.txt definition.

After this initial fix I ran into a second error:
```
CMake Error at ${ENV_PREFIX}/share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
      Could NOT find NCCL (missing: NCCL_LIBRARY)
    Call Stack (most recent call first):
      ${ENV_PREFIX}//share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
      cmake/Modules/FindNCCL.cmake:42 (find_package_handle_standard_args)
      CMakeLists.txt:195 (find_package)
```
I figured, that this is an already known Horovod [error ](https://github.com/horovod/horovod/issues/1944#)when NCCL is installed via conda.

Minor additions include the adjustment of the CUDA version and the example of the working Horovod version.

I hope that these fixes will be useful for other folks!

Best wishes,

Eric